### PR TITLE
- hot fix: StringSerializableJsonConverter now internally uses a conc…

### DIFF
--- a/DotNetXtensions.Json/DotNetXtensions.Json.csproj
+++ b/DotNetXtensions.Json/DotNetXtensions.Json.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<Version>3.1.1</Version>
-		<AssemblyVersion>3.1.1.0</AssemblyVersion>
-		<FileVersion>3.1.1.0</FileVersion>
+		<Version>3.2.0</Version>
+		<AssemblyVersion>3.2.0.0</AssemblyVersion>
+		<FileVersion>3.2.0.0</FileVersion>
 		<Authors>Nicholas Petersen</Authors>
 		<RepositoryUrl>https://github.com/copernicus365/DotNetXtensions/tree/master/DotNetXtensions.Json</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/copernicus365/DotNetXtensions/tree/master/DotNetXtensions.Json</PackageProjectUrl>

--- a/DotNetXtensions.Json/src/JsonConverters/StringSerializableJsonConverter.cs
+++ b/DotNetXtensions.Json/src/JsonConverters/StringSerializableJsonConverter.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
+using System.Collections.Concurrent;
+
 using Newtonsoft.Json;
 
 namespace DotNetXtensions.Json
@@ -34,7 +35,7 @@ namespace DotNetXtensions.Json
 		// would greatly help performance for that instance though). Note that this type is not built 
 		// customizable, it does it's thing for IStringSerializable types and them alone, there's no reason therefore
 		// we can't cache these types
-		static Dictionary<Type, CanConvertType> _canConvertTypesDict = new Dictionary<Type, CanConvertType>();
+		static ConcurrentDictionary<Type, CanConvertType> _canConvertTypesDict = new ConcurrentDictionary<Type, CanConvertType>();
 
 		public override bool CanConvert(Type t)
 		{
@@ -48,7 +49,7 @@ namespace DotNetXtensions.Json
 
 			if(c.HadNullable)
 				_canConvertTypesDict[c.type] = c;
-			
+
 			return c.IsStringSerializable;
 		}
 


### PR DESCRIPTION
…urrent dictionary for type resolving, solves concurrent issues.